### PR TITLE
Add .wb-break-all utility

### DIFF
--- a/lib/typography.scss
+++ b/lib/typography.scss
@@ -182,13 +182,15 @@
 /* Set the font weight to bold */
 .text-bold { font-weight: $font-weight-bold !important;}
 /* Set the font to italic */
-.text-italic { font-style: italic !important;}
+.text-italic { font-style: italic !important; }
 /* Make text uppercase */
 .text-uppercase { text-transform: uppercase !important; }
 /* Underline text */
 .no-underline { text-decoration: none !important; }
 /* Don't wrap white space */
-.no-wrap { white-space: nowrap !important;}
+.no-wrap { white-space: nowrap !important; }
+/* Allow long lines with no spaces to line break */
+.wb-break-all { word-break: break-all !important; }
 
 .text-emphasized {
   font-weight: $font-weight-bold;


### PR DESCRIPTION
I chatted with @broccolini briefly this morning about adding this utility class for `word-break: break-all`. We use this in a few places already and I can see if those can be refactored to use this. 
